### PR TITLE
Add enrollment state management for nursery registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Aggiunge nella scheda **Contatti (res.partner)** una tab **“Asilo Nido”** co
   - **Comune di nascita**
   - **Codice Fiscale** (check lunghezza 16)
   - **Protocollo iscrizione**
+  - **Stato iscrizione** (pre-iscrizione, iscritto, ritirato)
   - **File PDF dell'iscrizione**
 - Tab dedicata in form partner con tree inline editabile + form
 

--- a/models/pb_nido_iscritto.py
+++ b/models/pb_nido_iscritto.py
@@ -19,6 +19,16 @@ class PbNidoIscritto(models.Model):
     comune_nascita = fields.Char("Comune di nascita")
     codice_fiscale = fields.Char("Codice Fiscale", size=16, help="16 caratteri")
     protocollo_iscrizione = fields.Char("Protocollo iscrizione")
+    iscrizione_state = fields.Selection(
+        [
+            ("pre_iscrizione", "Pre-iscrizione"),
+            ("iscritto", "Iscritto"),
+            ("ritirato", "Ritirato"),
+        ],
+        string="Stato iscrizione",
+        default="pre_iscrizione",
+        help="Stato della domanda di iscrizione dell'iscritto.",
+    )
     iscrizione_pdf = fields.Binary("Iscrizione (PDF)", attachment=True)
     iscrizione_filename = fields.Char("Nome file")
 

--- a/views/res_partner_views.xml
+++ b/views/res_partner_views.xml
@@ -11,6 +11,7 @@
         <field name="comune_nascita"/>
         <field name="codice_fiscale"/>
         <field name="protocollo_iscrizione"/>
+        <field name="iscrizione_state"/>
         <field name="iscrizione_pdf" filename="iscrizione_filename"/>
         <field name="iscrizione_filename"/>
       </list>
@@ -35,6 +36,7 @@
               <field name="comune_nascita"/>
               <field name="codice_fiscale"/>
               <field name="protocollo_iscrizione"/>
+              <field name="iscrizione_state"/>
               <field name="iscrizione_pdf" filename="iscrizione_filename"/>
               <field name="iscrizione_filename"/>
             </group>


### PR DESCRIPTION
## Summary
- add a selection field on pb.nido.iscritto to track the enrollment status
- expose the new status in the list and form views embedded in partners
- document the available enrollment states in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54f02a1dc8331907a723b3d2d8e92